### PR TITLE
Set OpenStack as the default datasource

### DIFF
--- a/elements/ubuntu/environment.d/99-cloud-init-datasources.bash
+++ b/elements/ubuntu/environment.d/99-cloud-init-datasources.bash
@@ -1,4 +1,5 @@
 # NOTE(adam_g): Until (LP: #1316475) is resolved in Ubuntu, default to only
 # allowing the Ec2 data source from being queried on first boot, unless
 # specified otherwise.
-export DIB_CLOUD_INIT_DATASOURCES=${DIB_CLOUD_INIT_DATASOURCES:-"Ec2"}
+# NOTE Changed Ec2 to OpenStack due to CCCP-1592
+export DIB_CLOUD_INIT_DATASOURCES=${DIB_CLOUD_INIT_DATASOURCES:-"OpenStack"}

--- a/elements/ubuntu/pre-install.d/99-set-cloud-init-datasource-config
+++ b/elements/ubuntu/pre-install.d/99-set-cloud-init-datasource-config
@@ -1,0 +1,10 @@
+#!/bin/bash
+cat >/etc/cloud/cloud.cfg.d/99-openstack-datasource.cfg <<EOL
+#cloud-config
+datasource:
+ OpenStack:
+  metadata_urls: ["http://169.254.169.254"]
+  max_wait: -1
+  timeout: 10
+  retries: 5
+EOL


### PR DESCRIPTION
Set OpenStack as the default datasource for metadata. Write default configuration
for said datasource explicitly into a config file.