### PR TITLE
Add Nvidia Cuda elements to build GPU Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .tox
 *.egg
 *.egg-info
+*.eggs
 dist
 *.qcow2
 *.raw

--- a/elements/nvidia-cuda/post-install.d/01-nvidia-cuda-install
+++ b/elements/nvidia-cuda/post-install.d/01-nvidia-cuda-install
@@ -1,0 +1,11 @@
+#!/bin/bash -lv
+
+if [ "$DISTRO_NAME" = "centos7" ]; then
+    yum install -y vim ntp deltarpm 
+    yum install -y cuda
+else
+    apt-get -y install vim ntp python linux-headers-generic
+    apt-get -y install cuda
+fi
+
+exit 0

--- a/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
+++ b/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
@@ -1,0 +1,11 @@
+#!/bin/bash -lv
+
+if [ "$DISTRO_NAME" = "centos7" ]; then
+    yum install -y https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-8.0.61-1.x86_64.rpm
+else
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+    dpkg -i cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+    apt-get update
+fi
+
+exit 0


### PR DESCRIPTION
Add elements to build images with Nvidia Cuda drivers and apps installed on
them. This will create a CentOS7 and Ubuntu-16.04 gpu images.